### PR TITLE
Fixing build -- missing headers fixed

### DIFF
--- a/src/problem/ProblemTypes.hpp
+++ b/src/problem/ProblemTypes.hpp
@@ -19,6 +19,7 @@
 
 #include <iostream>
 #include <vector>
+#include <cstdint>
 
 namespace d4 {
 


### PR DESCRIPTION
Without this, I'm getting:

```
[6/58] Building CXX object CMakeFiles/d4.dir/src/heuristics/PartitioningHeuristicNone.cpp.o
FAILED: CMakeFiles/d4.dir/src/heuristics/PartitioningHeuristicNone.cpp.o
/usr/lib/ccache/bin/c++ -DBOOST_PROGRAM_OPTIONS_NO_LIB -I/home/soos/development/sat_solvers/d4v2 -I/home/soos/development/sat_solvers/d4v2/3rdParty/glucose-3.0 -I/home/soos/development/sat_solvers/d4v2/3rdParty/kahypar -O3 -DNDEBUG -fPIE -std=c++17 -Wall -O3 -Wno-class-memaccess -Wno-format -Wno-misleading-indentation -Wno-literal-suffix -Wno-sign-compare -Wno-parentheses -MD -MT CMakeFiles/d4.dir/src/heuristics/PartitioningHeuristicNone.cpp.o -MF CMakeFiles/d4.dir/src/heuristics/PartitioningHeuristicNone.cpp.o.d -o CMakeFiles/d4.dir/src/heuristics/PartitioningHeuristicNone.cpp.o -c /home/soos/development/sat_solvers/d4v2/src/heuristics/PartitioningHeuristicNone.cpp
In file included from /home/soos/development/sat_solvers/d4v2/src/heuristics/PartitioningHeuristicNone.hpp:19,
                 from /home/soos/development/sat_solvers/d4v2/src/heuristics/PartitioningHeuristicNone.cpp:19:
/home/soos/development/sat_solvers/d4v2/src/problem/ProblemTypes.hpp:26:9: error: ‘uint8_t’ does not name a type
   26 | typedef uint8_t lbool;
      |         ^~~~~~~
/home/soos/development/sat_solvers/d4v2/src/problem/ProblemTypes.hpp:22:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   21 | #include <vector>
  +++ |+#include <cstdint>
   22 |
/home/soos/development/sat_solvers/d4v2/src/problem/ProblemTypes.hpp:29:7: error: ‘lbool’ does not name a type; did you mean ‘bool’?
   29 | const lbool l_True = 0;
      |       ^~~~~
      |       bool
/home/soos/development/sat_solvers/d4v2/src/problem/ProblemTypes.hpp:30:7: error: ‘lbool’ does not name a type; did you mean ‘bool’?
   30 | const lbool l_False = 1;
      |       ^~~~~
      |       bool
/home/soos/development/sat_solvers/d4v2/src/problem/ProblemTypes.hpp:31:7: error: ‘lbool’ does not name a type; did you mean ‘bool’?
   31 | const lbool l_Undef = 2;
      |       ^~~~~
      |       bool
In file included from /home/soos/development/sat_solvers/d4v2/src/heuristics/PartitioningHeuristic.hpp:26,
                 from /home/soos/development/sat_solvers/d4v2/src/heuristics/PartitioningHeuristicNone.hpp:22:
/home/soos/development/sat_solvers/d4v2/src/solvers/WrapperSolver.hpp:54:23: error: ‘lbool’ was not declared in this scope; did you mean ‘bool’?
   54 |   virtual std::vector<lbool> &getModel() = 0;
      |                       ^~~~~
      |                       bool
/home/soos/development/sat_solvers/d4v2/src/solvers/WrapperSolver.hpp:54:28: error: template argument 1 is invalid
   54 |   virtual std::vector<lbool> &getModel() = 0;
      |                            ^
/home/soos/development/sat_solvers/d4v2/src/solvers/WrapperSolver.hpp:54:28: error: template argument 2 is invalid
/home/soos/development/sat_solvers/d4v2/src/solvers/WrapperSolver.hpp:55:11: error: ‘lbool’ does not name a type; did you mean ‘bool’?
   55 |   virtual lbool getModelVar(Var v) = 0;
      |           ^~~~~
      |           bool
[8/58] Building CXX object CMakeFiles/d4.dir/src/heuristics/PhaseHeuristicPolarity.cpp.o
FAILED: CMakeFiles/d4.dir/src/heuristics/PhaseHeuristicPolarity.cpp.o
/usr/lib/ccache/bin/c++ -DBOOST_PROGRAM_OPTIONS_NO_LIB -I/home/soos/development/sat_solvers/d4v2 -I/home/soos/development/sat_solvers/d4v2/3rdParty/glucose-3.0 -I/home/soos/development/sat_solvers/d4v2/3rdParty/kahypar -O3 -DNDEBUG -fPIE -std=c++17 -Wall -O3 -Wno-class-memaccess -Wno-format -Wno-misleading-indentation -Wno-literal-suffix -Wno-sign-compare -Wno-parentheses -MD -MT CMakeFiles/d4.dir/src/heuristics/PhaseHeuristicPolarity.cpp.o -MF CMakeFiles/d4.dir/src/heuristics/PhaseHeuristicPolarity.cpp.o.d -o CMakeFiles/d4.dir/src/heuristics/PhaseHeuristicPolarity.cpp.o -c /home/soos/development/sat_solvers/d4v2/src/heuristics/PhaseHeuristicPolarity.cpp
In file included from /home/soos/development/sat_solvers/d4v2/src/solvers/PolarityManager.hpp:20,
                 from /home/soos/development/sat_solvers/d4v2/src/heuristics/PhaseHeuristicPolarity.hpp:19,
                 from /home/soos/development/sat_solvers/d4v2/src/heuristics/PhaseHeuristicPolarity.cpp:19:
/home/soos/development/sat_solvers/d4v2/src/problem/ProblemTypes.hpp:26:9: error: ‘uint8_t’ does not name a type
   26 | typedef uint8_t lbool;
      |         ^~~~~~~
/home/soos/development/sat_solvers/d4v2/src/problem/ProblemTypes.hpp:22:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   21 | #include <vector>
  +++ |+#include <cstdint>
   22 |
/home/soos/development/sat_solvers/d4v2/src/problem/ProblemTypes.hpp:29:7: error: ‘lbool’ does not name a type; did you mean ‘bool’?
   29 | const lbool l_True = 0;
      |       ^~~~~
      |       bool
/home/soos/development/sat_solvers/d4v2/src/problem/ProblemTypes.hpp:30:7: error: ‘lbool’ does not name a type; did you mean ‘bool’?
   30 | const lbool l_False = 1;
      |       ^~~~~
      |       bool
/home/soos/development/sat_solvers/d4v2/src/problem/ProblemTypes.hpp:31:7: error: ‘lbool’ does not name a type; did you mean ‘bool’?
   31 | const lbool l_Undef = 2;
      |       ^~~~~
      |       bool
[23/58] Building CXX object CMakeFiles/d4.dir/src/heuristics/cnf/PartitioningHeuristicStaticSinglePrimal.cpp.o
ninja: build stopped: subcommand failed.
```

I don't really expect this to be merged, you can just close it, but perhaps you can fix nevertheless :)

I hope this helps,

Mate